### PR TITLE
Update TCK results to report the https://github.com/jakartaee/securit…

### DIFF
--- a/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk11.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk11.adoc
@@ -657,8 +657,8 @@ SHA-256: `696776046dfeaed74266a5d1c4dac7fea5437b6f51743b7fe10962dde755ff8f`
 
 TCK result summary:
 ----
-Completed running 117 tests.
-Number of Tests Failed      = 2 (two test failures are challenged via https://github.com/jakartaee/security/issues/270)
+Completed running 115 tests.
+Number of Tests Failed      = 0
 Number of Tests with Errors = 0
 ----
 ----
@@ -667,6 +667,8 @@ Number of Tests with Errors = 0
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 ----
+
+(Two tests were excluded due to the challenge at https://github.com/jakartaee/security/issues/270.)
 
 https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip[Jakarta XML Binding 4.0.0 TCK]
 

--- a/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk17.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk17.adoc
@@ -657,8 +657,8 @@ SHA-256: `696776046dfeaed74266a5d1c4dac7fea5437b6f51743b7fe10962dde755ff8f`
 
 TCK result summary:
 ----
-Completed running 117 tests.
-Number of Tests Failed      = 2 (two test failures are challenged via https://github.com/jakartaee/security/issues/270)
+Completed running 115 tests.
+Number of Tests Failed      = 0
 Number of Tests with Errors = 0
 ----
 ----
@@ -667,6 +667,8 @@ Number of Tests with Errors = 0
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 ----
+
+(Two tests were excluded due to the challenge at https://github.com/jakartaee/security/issues/270.)
 
 https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip[Jakarta XML Binding 4.0.0 TCK]
 

--- a/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk11.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk11.adoc
@@ -302,8 +302,8 @@ SHA-256: `696776046dfeaed74266a5d1c4dac7fea5437b6f51743b7fe10962dde755ff8f`
 
 TCK result summary:
 ----
-Completed running 117 tests.
-Number of Tests Failed      = 2 (two test failures are challenged via https://github.com/jakartaee/security/issues/270)
+Completed running 115 tests.
+Number of Tests Failed      = 0
 Number of Tests with Errors = 0
 ----
 ----
@@ -312,6 +312,8 @@ Number of Tests with Errors = 0
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 ----
+
+(Two tests were excluded due to the challenge at https://github.com/jakartaee/security/issues/270.)
 
 https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip[Jakarta XML Binding 4.0.0 TCK]
 

--- a/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk17.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk17.adoc
@@ -302,8 +302,8 @@ SHA-256: `696776046dfeaed74266a5d1c4dac7fea5437b6f51743b7fe10962dde755ff8f`
 
 TCK result summary:
 ----
-Completed running 117 tests.
-Number of Tests Failed      = 2 (two test failures are challenged via https://github.com/jakartaee/security/issues/270)
+Completed running 115 tests.
+Number of Tests Failed      = 0
 Number of Tests with Errors = 0
 ----
 ----
@@ -312,6 +312,8 @@ Number of Tests with Errors = 0
 [javatest.batch] Number of Tests Failed      = 0
 [javatest.batch] Number of Tests with Errors = 0
 ----
+
+(Two tests were excluded due to the challenge at https://github.com/jakartaee/security/issues/270.)
 
 https://download.eclipse.org/jakartaee/xml-binding/4.0/jakarta-xml-binding-tck-4.0.0.zip[Jakarta XML Binding 4.0.0 TCK]
 


### PR DESCRIPTION
…y/issues/270 challenged tests as excluded instead of failed.

This reflects new test runs following the https://github.com/wildfly/wildfly-tck-runners/pull/55 update to the WildFly TCK runner.

Signed-off-by: Brian Stansberry <brian.stansberry@redhat.com>

@scottmarlow This change seems optional and is primarily in case we wish to update our comments related to the security challenge on our CCR PRs at Jakarta (https://github.com/eclipse-ee4j/jakartaee-platform/issues/539 and https://github.com/eclipse-ee4j/jakartaee-platform/issues/540).