### PR TITLE
switch to https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip with same SHA

### DIFF
--- a/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk11.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk11.adoc
@@ -25,7 +25,7 @@ Specification Name, Version and download URL:
 https://jakarta.ee/specifications/platform/10[Jakarta EE Platform, 10]
 
 TCK Version, digital SHA-256 fingerprint and download URL:
-https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e ]
+https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e ]
 
 Public URL of TCK Results Summary:
 https://github.com/wildfly/certifications/blob/EE10/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk11.adoc#tck-results[WildFly 27.0.0.Alpha5 TCK results]

--- a/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk17.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk17.adoc
@@ -25,7 +25,7 @@ Specification Name, Version and download URL:
 https://jakarta.ee/specifications/platform/10[Jakarta EE Platform, 10]
 
 TCK Version, digital SHA-256 fingerprint and download URL:
-https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e ]
+https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e ]
 
 Public URL of TCK Results Summary:
 https://github.com/wildfly/certifications/blob/EE10/WildFly_27.0.0.Alpha5/jakarta-full-platform-jdk17.adoc#tck-results[WildFly 27.0.0.Alpha5 TCK results]

--- a/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk11.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk11.adoc
@@ -25,7 +25,7 @@ Specification Name, Version and download URL:
 https://jakarta.ee/specifications/webprofile/10/[Jakarta EE Platform, Web Profile 10]
 
 TCK Version, digital SHA-256 fingerprint and download URL:
-https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e  ]
+https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e  ]
 
 Public URL of TCK Results Summary: 
 https://github.com/wildfly/certifications/blob/EE10/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk11.adoc#tck-results[WildFly 27.0.0.Alpha5 TCK results]

--- a/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk17.adoc
+++ b/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk17.adoc
@@ -25,7 +25,7 @@ Specification Name, Version and download URL:
 https://jakarta.ee/specifications/webprofile/10/[Jakarta EE Platform, Web Profile 10]
 
 TCK Version, digital SHA-256 fingerprint and download URL:
-https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee10/staged/eftl/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e  ]
+https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip[Jakarta EE Platform TCK 10, 7874244f69ed9c72f4d4b5a8c48b21d39c56f4b877b1d4d735247a7f08215a5e  ]
 
 Public URL of TCK Results Summary: 
 https://github.com/wildfly/certifications/blob/EE10/WildFly_27.0.0.Alpha5/jakarta-web-profile-jdk17.adoc#tck-results[WildFly 27.0.0.Alpha5 TCK results]


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

Sync with changes made to https://github.com/eclipse-ee4j/jakartaee-platform/issues/539 + https://github.com/eclipse-ee4j/jakartaee-platform/issues/540 to use https://download.eclipse.org/jakartaee/platform/10/jakarta-jakartaeetck-10.0.0.zip